### PR TITLE
Redundant code reduced, maintainability improved

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -8,31 +8,28 @@ plasma | plasmawayland | cinnamon)
         Installation_Method="QT"
         Installation_Path=~/.local/share/icons
         ;;
-*)
-        Installation_Method="Generic"
-        Installation_Path="/usr/share/icons"
 esac
 
 function Delta_Apply () {
         echo "Running $Installation_Method installation"
-        rm -rf $Installation_Path/Delta
-        mkdir -p Delta $Installation_Path
+        rm -rf "$Installation_Path"/Delta
+        mkdir -p Delta "$Installation_Path"
         curl -L -O https://github.com/Delta-Icons/linux/releases/latest/download/delta-linux.zip
         case $Installation_Method in
         Generic)
                 unzip -d delta-linux delta-linux.zip > /dev/null
-                sudo mv delta-linux/ $Installation_Path
+                sudo mv delta-linux/ "$Installation_Path"
                 ;;
         *)
-                unzip  delta-linux.zip -d $Installation_Path > /dev/null
+                unzip  delta-linux.zip -d "$Installation_Path" > /dev/null
                 ;;
         esac
         echo "Installed"
 }
 
 echo "Current desktop: $DESKTOP_SESSION"
-case $DESKTOP_SESSION in
-gnome | xubuntu | budgie-desktop | pantheon | xfce | plasma | plasmawayland | cinnamon)
+case $Installation_Method in
+GTK)
         case $Installation_Method in
         GTK)
                 echo "$DESKTOP_SESSION supports fully automated install"
@@ -43,37 +40,38 @@ gnome | xubuntu | budgie-desktop | pantheon | xfce | plasma | plasmawayland | ci
                 ;;
         esac
         read -r -p "Do You wish to continue? y/n " proceed
-                case $proceed in
-                y)
-                        case $Installation_Method in
-                        GTK)
-                                Delta_Apply
-                                case $DESKTOP_SESSION in
-                                xfce)
-                                        xfconf-query -c xsettings -p /Net/IconThemeName -s "Delta"
-                                        ;;
-                                *)
-                                        gsettings set org.gnome.desktop.interface icon-theme "Delta"
-                                        ;;
-                                esac
+        case $proceed in
+        y)
+                case $Installation_Method in
+                GTK)
+                        Delta_Apply
+                        case $DESKTOP_SESSION in
+                        xfce)
+                                xfconf-query -c xsettings -p /Net/IconThemeName -s "Delta"
                                 ;;
-                        QT)
-                                Delta_Apply
-                                echo "Delta has been moved, You can now apply Delta from your settings panel"
-                                echo "Coming soon to your local customisation store!"
+                        *)
+                                gsettings set org.gnome.desktop.interface icon-theme "Delta"
                                 ;;
                         esac
+                        ;;
+                QT)
+                        Delta_Apply
+                        echo "Delta has been moved, You can now apply Delta \
+                        from your settings panel"
+                        echo "Coming soon to your local customisation store!"
+                        ;;
+                esac
                         rm -rf delta-linux.zip
                         rm -rf delta-linux
                         ;;
-                n)
-                        exit 0
-                        ;;
-                *)
-                        echo "invalid input"
-                        ;;
-                esac
+        n)
+                exit 0
                 ;;
+        *)
+                echo "invalid input"
+                ;;
+        esac
+        ;;
 *)
         echo "Your Desktop Environment isn't recognised or isn't \
         supported yet, Please open an issue on the Linux branch, \
@@ -100,7 +98,7 @@ gnome | xubuntu | budgie-desktop | pantheon | xfce | plasma | plasmawayland | ci
                 ;;
         3)
                 Installation_Method="Generic"
-                Installation_Path=~/.local/share/icons
+                Installation_Path=/usr/share/icons
                 Delta_Apply
                 echo "You should now try and apply the icon pack"
                 ;;


### PR DESCRIPTION
Removed "Generic" installation path as that was redundant and useless,
improved maintainability, now to add more supported installation methods, we just have to add them to the top
Fixed the code tab level for readability
also fixed ``~/.local/share/icons`` for common install to the proper ``/usr/local/share``